### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Twitter.MixProject do
       # Phoenix
       {:phoenix, "~> 1.7.0-rc.0", override: true},
       {:phoenix_ecto, "~> 4.4"},
-      {:ecto_sql, "~> 3.6"},
+      {:ecto_sql, "~> 3.10.2"},
       {:postgrex, ">= 0.0.0"},
       {:phoenix_html, "~> 3.0"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},


### PR DESCRIPTION
```
== Compilation error in file lib/ecto/query.ex ==
** (Kernel.TypespecError) lib/ecto/query.ex:428: type dynamic/0 is a built-in type and it cannot be redefined
    (elixir 1.15.0) lib/kernel/typespec.ex:961: Kernel.Typespec.compile_error/2
    (stdlib 5.0.1) lists.erl:1599: :lists.foldl_1/3
    (elixir 1.15.0) lib/kernel/typespec.ex:226: Kernel.Typespec.translate_typespecs_for_module/2
could not compile dependency :ecto, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile ecto --force", update it with "mix deps.update ecto" or clean it with "mix deps.clean ecto"
```

> Update the ecto version to {:ecto, "~> 3.10"} version as the latest OTP and ecto was having the type dynamic in common. so ecto updated the name to dynamic_expr so to fix this issue. either upgrade the ecto or downgrade the OTP.

